### PR TITLE
Update ed25519 library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ tiny-keccak = { version = "2.0.2", features = ["keccak"] }
 zeroize = "1.1.0"
 libsecp256k1 = { version = "0.3.5", optional = true }
 serde = { version = "1.0.110", optional = true }
-ed25519-dalek = { version = "1.0.0-pre.3", optional = true }
+ed25519-dalek = { version = "1.0.0-pre.4", optional = true }
 c-secp256k1 = { package = "secp256k1", version = "0.17.2", optional = true }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "enr"
 authors = ["Age Manning <Age@AgeManning.com>"]
 edition = "2018"
-version = "0.1.0"
+version = "0.1.1"
 description = "Rust implementation of Ethereum Node Record (ENR) EIP778"
 readme = "./README.md"
 keywords = ["ethereum", "enr", "record", "EIP778", "node"]

--- a/src/keys/ed25519.rs
+++ b/src/keys/ed25519.rs
@@ -1,6 +1,8 @@
-use super::{ed25519_dalek as ed25519, EnrKey, EnrPublicKey, SigningError};
+use super::ed25519_dalek::{self as ed25519, Signer as _, Verifier as _};
+use super::{EnrKey, EnrPublicKey, SigningError};
 use rlp::DecoderError;
 use std::collections::BTreeMap;
+use std::convert::TryFrom;
 
 /// The ENR key that stores the public key in the ENR record.
 pub const ENR_KEY: &str = "ed25519";
@@ -35,7 +37,7 @@ impl EnrKey for ed25519::Keypair {
 impl EnrPublicKey for ed25519::PublicKey {
     /// Verify a raw message, given a public key for the v4 identity scheme.
     fn verify_v4(&self, msg: &[u8], sig: &[u8]) -> bool {
-        ed25519::Signature::from_bytes(sig)
+        ed25519::Signature::try_from(sig)
             .and_then(|s| self.verify(msg, &s))
             .is_ok()
     }


### PR DESCRIPTION
The ed25519 library has been updated and breaks compilation. 

This PR updates the ENR crate to the latest ed25519 library. 