### PR TITLE
Fuzz

### DIFF
--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,4 @@
+
+target
+corpus
+artifacts

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -12,14 +12,19 @@ cargo-fuzz = true
 [dependencies]
 libfuzzer-sys = "0.3"
 rlp = "0.4.3"
+base64 = "0.12.1"
 
 [dependencies.enr]
 path = ".."
-features = ["ed25519", "serde", "libsecp256k1"]
 
 # Prevent this from interfering with workspaces
 [workspace]
 members = ["."]
+
+[features]
+default = ["enr/serde", "enr/libsecp256k1", "enr/ed25519"]
+# c-secp256k1 = ["enr/serde", "enr/c-secp256k1"]
+
 
 [[bin]]
 name = "fuzz_decode"
@@ -32,3 +37,11 @@ path = "fuzz_targets/fuzz_decode_ed25519.rs"
 [[bin]]
 name = "fuzz_decode_combined"
 path = "fuzz_targets/fuzz_decode_combined.rs"
+
+[[bin]]
+name = "fuzz_from_str"
+path = "fuzz_targets/fuzz_from_str.rs"
+
+[[bin]]
+name = "fuzz_from_str_base64"
+path = "fuzz_targets/fuzz_from_str_base64.rs"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,34 @@
+
+[package]
+name = "enr-fuzz"
+version = "0.0.0"
+authors = ["Automatically generated"]
+publish = false
+edition = "2018"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.3"
+rlp = "0.4.3"
+
+[dependencies.enr]
+path = ".."
+features = ["ed25519", "serde", "libsecp256k1"]
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[[bin]]
+name = "fuzz_decode"
+path = "fuzz_targets/fuzz_decode.rs"
+
+[[bin]]
+name = "fuzz_decode_ed25519"
+path = "fuzz_targets/fuzz_decode_ed25519.rs"
+
+[[bin]]
+name = "fuzz_decode_combined"
+path = "fuzz_targets/fuzz_decode_combined.rs"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -10,25 +10,25 @@ edition = "2018"
 cargo-fuzz = true
 
 [dependencies]
-libfuzzer-sys = "0.3"
+libfuzzer-sys = "0.2"
 rlp = "0.4.3"
 base64 = "0.12.1"
 
 [dependencies.enr]
 path = ".."
+features = ["serde", "libsecp256k1", "ed25519", "rust-secp256k1"]
 
 # Prevent this from interfering with workspaces
 [workspace]
 members = ["."]
 
-[features]
-default = ["enr/serde", "enr/libsecp256k1", "enr/ed25519"]
-# c-secp256k1 = ["enr/serde", "enr/c-secp256k1"]
-
-
 [[bin]]
 name = "fuzz_decode"
 path = "fuzz_targets/fuzz_decode.rs"
+
+[[bin]]
+name = "fuzz_decode_c_secp"
+path = "fuzz_targets/fuzz_decode_c_secp.rs"
 
 [[bin]]
 name = "fuzz_decode_ed25519"
@@ -45,3 +45,7 @@ path = "fuzz_targets/fuzz_from_str.rs"
 [[bin]]
 name = "fuzz_from_str_base64"
 path = "fuzz_targets/fuzz_from_str_base64.rs"
+
+[[bin]]
+name = "fuzz_from_str_c_secp"
+path = "fuzz_targets/fuzz_from_str_c_secp.rs"

--- a/fuzz/fuzz_targets/fuzz_decode.rs
+++ b/fuzz/fuzz_targets/fuzz_decode.rs
@@ -1,0 +1,12 @@
+#![no_main]
+#[macro_use] extern crate libfuzzer_sys;
+extern crate enr;
+extern crate rlp;
+
+use enr::{Enr, secp256k1::SecretKey};
+use rlp::Decodable;
+
+// Fuzz Enr::decode
+fuzz_target!(|data: &[u8]| {
+    rlp::decode::<Enr<SecretKey>>(&data);
+});

--- a/fuzz/fuzz_targets/fuzz_decode_c_secp.rs
+++ b/fuzz/fuzz_targets/fuzz_decode_c_secp.rs
@@ -4,7 +4,7 @@ extern crate libfuzzer_sys;
 extern crate enr;
 extern crate rlp;
 
-use enr::{secp256k1::SecretKey, Enr};
+use enr::{c_secp256k1::SecretKey, Enr};
 use rlp::Decodable;
 
 // Fuzz Enr::decode

--- a/fuzz/fuzz_targets/fuzz_decode_combined.rs
+++ b/fuzz/fuzz_targets/fuzz_decode_combined.rs
@@ -1,9 +1,10 @@
 #![no_main]
-#[macro_use] extern crate libfuzzer_sys;
+#[macro_use]
+extern crate libfuzzer_sys;
 extern crate enr;
 extern crate rlp;
 
-use enr::{Enr, CombinedKey};
+use enr::{CombinedKey, Enr};
 use rlp::Decodable;
 
 // Fuzz Enr::decode

--- a/fuzz/fuzz_targets/fuzz_decode_combined.rs
+++ b/fuzz/fuzz_targets/fuzz_decode_combined.rs
@@ -1,0 +1,12 @@
+#![no_main]
+#[macro_use] extern crate libfuzzer_sys;
+extern crate enr;
+extern crate rlp;
+
+use enr::{Enr, CombinedKey};
+use rlp::Decodable;
+
+// Fuzz Enr::decode
+fuzz_target!(|data: &[u8]| {
+    rlp::decode::<Enr<CombinedKey>>(&data);
+});

--- a/fuzz/fuzz_targets/fuzz_decode_ed25519.rs
+++ b/fuzz/fuzz_targets/fuzz_decode_ed25519.rs
@@ -1,9 +1,10 @@
 #![no_main]
-#[macro_use] extern crate libfuzzer_sys;
+#[macro_use]
+extern crate libfuzzer_sys;
 extern crate enr;
 extern crate rlp;
 
-use enr::{Enr, ed25519_dalek::Keypair};
+use enr::{ed25519_dalek::Keypair, Enr};
 use rlp::Decodable;
 
 // Fuzz Enr::decode

--- a/fuzz/fuzz_targets/fuzz_decode_ed25519.rs
+++ b/fuzz/fuzz_targets/fuzz_decode_ed25519.rs
@@ -1,0 +1,12 @@
+#![no_main]
+#[macro_use] extern crate libfuzzer_sys;
+extern crate enr;
+extern crate rlp;
+
+use enr::{Enr, ed25519_dalek::Keypair};
+use rlp::Decodable;
+
+// Fuzz Enr::decode
+fuzz_target!(|data: &[u8]| {
+    rlp::decode::<Enr<Keypair>>(&data);
+});

--- a/fuzz/fuzz_targets/fuzz_from_str.rs
+++ b/fuzz/fuzz_targets/fuzz_from_str.rs
@@ -1,0 +1,14 @@
+#![no_main]
+#[macro_use] extern crate libfuzzer_sys;
+extern crate enr;
+extern crate rlp;
+
+use enr::{Enr, CombinedKey};
+use rlp::Decodable;
+use std::str::FromStr;
+
+// Fuzz Enr::decode
+fuzz_target!(|data: &[u8]| {
+    let utf8_str = String::from_utf8_lossy(data);
+    let _: Result<Enr<CombinedKey>, _> = Enr::from_str(&utf8_str);
+});

--- a/fuzz/fuzz_targets/fuzz_from_str_base64.rs
+++ b/fuzz/fuzz_targets/fuzz_from_str_base64.rs
@@ -1,0 +1,16 @@
+#![no_main]
+#[macro_use] extern crate libfuzzer_sys;
+extern crate enr;
+extern crate rlp;
+
+use enr::{Enr, CombinedKey};
+use rlp::Decodable;
+use std::str::FromStr;
+
+// Fuzz Enr::decode
+fuzz_target!(|data: &[u8]| {
+    let base64_str = base64::encode(data);
+    let mut enr_str = "enr:".to_string();
+    enr_str.push_str(&base64_str);
+    let _res: Result<Enr<CombinedKey>, _> = Enr::from_str(&enr_str);
+});

--- a/fuzz/fuzz_targets/fuzz_from_str_base64.rs
+++ b/fuzz/fuzz_targets/fuzz_from_str_base64.rs
@@ -1,10 +1,9 @@
 #![no_main]
-#[macro_use] extern crate libfuzzer_sys;
+#[macro_use]
+extern crate libfuzzer_sys;
 extern crate enr;
-extern crate rlp;
 
-use enr::{Enr, CombinedKey};
-use rlp::Decodable;
+use enr::{CombinedKey, Enr};
 use std::str::FromStr;
 
 // Fuzz Enr::decode

--- a/fuzz/fuzz_targets/fuzz_from_str_c_secp.rs
+++ b/fuzz/fuzz_targets/fuzz_from_str_c_secp.rs
@@ -3,11 +3,11 @@
 extern crate libfuzzer_sys;
 extern crate enr;
 
-use enr::{CombinedKey, Enr};
+use enr::{c_secp256k1::SecretKey, Enr};
 use std::str::FromStr;
 
 // Fuzz Enr::decode
 fuzz_target!(|data: &[u8]| {
     let utf8_str = String::from_utf8_lossy(data);
-    let _: Result<Enr<CombinedKey>, _> = Enr::from_str(&utf8_str);
+    let _: Result<Enr<SecretKey>, _> = Enr::from_str(&utf8_str);
 });


### PR DESCRIPTION
# What has been Done

Adds fuzz targets for `from_str()` and `rpl::decode()` for each of the key types.

These fuzz targets are in a separate workspace and should not interfere with production code (and hopefully not the binaries).

The fuzzers can be run as any of the binaries listed in `fuzz/Cargo.toml` using `cargo fuzz` for example:

```bash
> cargo fuzz run fuzz_decode
```