### PR TITLE
k256 keys support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,9 @@ rlp = "0.4.5"
 tiny-keccak = { version = "2.0.2", features = ["keccak"] }
 zeroize = "1.1.0"
 libsecp256k1 = { version = "0.3.5", optional = true }
+ecdsa = { version = "0.7", optional = true }
+sha3 = { version = "0.9", optional = true }
+k256-crate = { package = "k256", version = "0.4", features = ["ecdsa"], optional = true }
 serde = { version = "1.0.110", optional = true }
 ed25519-dalek = { version = "1.0.0-pre.4", optional = true }
 c-secp256k1 = { package = "secp256k1", version = "0.17.2", optional = true }
@@ -35,6 +38,7 @@ c-secp256k1 = { package = "secp256k1", features = ["rand-std"], version = "0.17.
 default = ["serde", "libsecp256k1" ]
 ed25519 = ["ed25519-dalek"]
 rust-secp256k1 = ["c-secp256k1"]
+k256 = ["k256-crate", "ecdsa", "sha3"]
 
 [lib]
 name = "enr"

--- a/src/keys/k256.rs
+++ b/src/keys/k256.rs
@@ -1,0 +1,81 @@
+//! An implementation for `EnrKey` for `k256::SecretKey`
+
+use super::{EnrKey, EnrPublicKey, SigningError};
+use k256_crate::{
+    ecdsa::signature::{DigestVerifier, RandomizedDigestSigner, Signature},
+    elliptic_curve::weierstrass::public_key::FromPublicKey,
+};
+use rand::rngs::OsRng;
+use rlp::DecoderError;
+use sha3::{Digest, Keccak256};
+use std::{
+    collections::BTreeMap,
+    convert::{TryFrom, TryInto},
+};
+
+/// The ENR key that stores the public key in the ENR record.
+pub const ENR_KEY: &str = "secp256k1";
+
+type Signer = ecdsa::Signer<k256_crate::Secp256k1>;
+type Verifier = ecdsa::Verifier<k256_crate::Secp256k1>;
+
+impl EnrKey for k256_crate::SecretKey {
+    type PublicKey = k256_crate::PublicKey;
+
+    fn sign_v4(&self, msg: &[u8]) -> Result<Vec<u8>, SigningError> {
+        // take a keccak256 hash then sign.
+        let digest = Keccak256::new().chain(msg);
+        let signature: k256_crate::ecdsa::Signature = Signer::new(self)
+            .map_err(|_| SigningError::new("failed to create signer"))?
+            .sign_digest_with_rng(&mut OsRng, digest);
+
+        Ok(signature.as_bytes().to_vec())
+    }
+
+    fn public(&self) -> Self::PublicKey {
+        self.try_into().unwrap()
+    }
+
+    fn enr_to_public(content: &BTreeMap<String, Vec<u8>>) -> Result<Self::PublicKey, DecoderError> {
+        let pubkey_bytes = content
+            .get(ENR_KEY)
+            .ok_or_else(|| DecoderError::Custom("Unknown signature"))?;
+
+        // should be encoded in compressed form, i.e 33 byte raw secp256k1 public key
+        Ok(k256_crate::PublicKey::from_bytes(pubkey_bytes)
+            .ok_or_else(|| DecoderError::Custom("Invalid Secp256k1 Signature"))?)
+    }
+}
+
+impl EnrPublicKey for k256_crate::PublicKey {
+    fn verify_v4(&self, msg: &[u8], sig: &[u8]) -> bool {
+        let digest = Keccak256::new().chain(msg);
+        if let Ok(sig) = k256_crate::ecdsa::Signature::try_from(sig) {
+            if let Ok(verifier) = Verifier::new(self) {
+                if verifier.verify_digest(digest, &sig).is_ok() {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
+    fn encode(&self) -> Vec<u8> {
+        // serialize in compressed form: 33 bytes
+        let mut s = *self;
+        s.compress();
+        s.as_bytes().to_vec()
+    }
+
+    fn encode_uncompressed(&self) -> Vec<u8> {
+        k256_crate::AffinePoint::from_public_key(self)
+            .unwrap()
+            .to_pubkey(false)
+            .as_bytes()[1..]
+            .to_vec()
+    }
+
+    fn enr_key(&self) -> String {
+        ENR_KEY.into()
+    }
+}

--- a/src/keys/mod.rs
+++ b/src/keys/mod.rs
@@ -12,6 +12,8 @@
 mod combined;
 #[cfg(feature = "ed25519")]
 mod ed25519;
+#[cfg(feature = "k256")]
+mod k256;
 #[cfg(any(feature = "libsecp256k1", doc))]
 mod libsecp256k1;
 #[cfg(feature = "rust-secp256k1")]


### PR DESCRIPTION
This PR adds support for using ENR with secret and private keys from [k256](https://github.com/RustCrypto/elliptic-curves) crate of RustCrypto project. Big thanks to @tarcieri for helping with various papercuts.