### PR TITLE
Add cargo audit to CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,3 +59,14 @@ jobs:
         run: rustup update stable
       - name: Run tests in release
         run: cargo test --all --release --no-default-features --features "libsecp256k1","ed25519" --tests
+  cargo-audit:
+    runs-on: ubuntu-latest
+    needs: cargo-fmt
+    steps:
+      - uses: actions/checkout@v2
+      - name: Get latest version of stable rust
+        run: rustup update stable
+      - name: Get latest cargo audit
+        run: cargo install --force cargo-audit
+      - name: Run cargo audit to identify known security vulnerabilities reported to the RustSec Advisory Database
+        run: cargo audit


### PR DESCRIPTION
## Proposed Changes

Adds `cargo audit` to Github Actions to identify known security vulnerabilities reported to the [RustSec Advisory Database](https://github.com/RustSec/advisory-db/).

