### PR TITLE
Generalise ENR key type

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,3 +1,4 @@
+use crate::Key;
 use crate::{Enr, EnrError, EnrKey, EnrPublicKey, NodeId, MAX_ENR_SIZE};
 use rlp::RlpStream;
 use std::{collections::BTreeMap, marker::PhantomData, net::IpAddr};
@@ -11,7 +12,7 @@ pub struct EnrBuilder<K: EnrKey> {
     seq: u64,
 
     /// The key-value pairs for the ENR record.
-    content: BTreeMap<String, Vec<u8>>,
+    content: BTreeMap<Key, Vec<u8>>,
 
     /// Pins the generic key types.
     phantom: PhantomData<K>,
@@ -37,8 +38,8 @@ impl<K: EnrKey> EnrBuilder<K> {
     }
 
     /// Adds an arbitrary key-value to the `ENRBuilder`.
-    pub fn add_value(&mut self, key: String, value: Vec<u8>) -> &mut Self {
-        self.content.insert(key, value);
+    pub fn add_value(&mut self, key: impl AsRef<[u8]>, value: Vec<u8>) -> &mut Self {
+        self.content.insert(key.as_ref().to_vec(), value);
         self
     }
 
@@ -46,12 +47,10 @@ impl<K: EnrKey> EnrBuilder<K> {
     pub fn ip(&mut self, ip: IpAddr) -> &mut Self {
         match ip {
             IpAddr::V4(addr) => {
-                self.content
-                    .insert(String::from("ip"), addr.octets().to_vec());
+                self.content.insert(b"ip".to_vec(), addr.octets().to_vec());
             }
             IpAddr::V6(addr) => {
-                self.content
-                    .insert(String::from("ip6"), addr.octets().to_vec());
+                self.content.insert(b"ip6".to_vec(), addr.octets().to_vec());
             }
         }
         self

--- a/src/keys/combined.rs
+++ b/src/keys/combined.rs
@@ -10,6 +10,8 @@ pub use secp256k1;
 use std::collections::BTreeMap;
 use zeroize::Zeroize;
 
+use crate::Key;
+
 /// A standard implementation of the `EnrKey` trait used to sign and modify ENR records. The variants here represent the currently
 /// supported in-built signing schemes.
 pub enum CombinedKey {
@@ -64,7 +66,7 @@ impl EnrKey for CombinedKey {
     }
 
     /// Decodes the raw bytes of an ENR's content into a public key if possible.
-    fn enr_to_public(content: &BTreeMap<String, Vec<u8>>) -> Result<Self::PublicKey, DecoderError> {
+    fn enr_to_public(content: &BTreeMap<Key, Vec<u8>>) -> Result<Self::PublicKey, DecoderError> {
         secp256k1::SecretKey::enr_to_public(content)
             .map(CombinedPublicKey::Secp256k1)
             .or_else(|_| ed25519::Keypair::enr_to_public(content).map(CombinedPublicKey::from))
@@ -178,7 +180,7 @@ impl EnrPublicKey for CombinedPublicKey {
     }
 
     /// Generates the ENR public key string associated with the key type.
-    fn enr_key(&self) -> String {
+    fn enr_key(&self) -> Key {
         match self {
             Self::Secp256k1(key) => key.enr_key(),
             Self::Ed25519(key) => key.enr_key(),

--- a/src/keys/ed25519.rs
+++ b/src/keys/ed25519.rs
@@ -2,6 +2,7 @@ use super::{
     ed25519_dalek::{self as ed25519, Signer as _, Verifier as _},
     EnrKey, EnrPublicKey, SigningError,
 };
+use crate::Key;
 use rlp::DecoderError;
 use std::{collections::BTreeMap, convert::TryFrom};
 
@@ -25,9 +26,9 @@ impl EnrKey for ed25519::Keypair {
     }
 
     /// Decodes the raw bytes of an ENR's content into a public key if possible.
-    fn enr_to_public(content: &BTreeMap<String, Vec<u8>>) -> Result<Self::PublicKey, DecoderError> {
+    fn enr_to_public(content: &BTreeMap<Key, Vec<u8>>) -> Result<Self::PublicKey, DecoderError> {
         let pubkey_bytes = content
-            .get(ENR_KEY)
+            .get(ENR_KEY.as_bytes())
             .ok_or_else(|| DecoderError::Custom("Unknown signature"))?;
         ed25519::PublicKey::from_bytes(pubkey_bytes)
             .map_err(|_| DecoderError::Custom("Invalid ed25519 Signature"))
@@ -54,7 +55,7 @@ impl EnrPublicKey for ed25519::PublicKey {
     }
 
     /// Generates the ENR public key string associated with the ed25519 key type.
-    fn enr_key(&self) -> String {
+    fn enr_key(&self) -> Key {
         ENR_KEY.into()
     }
 }

--- a/src/keys/k256.rs
+++ b/src/keys/k256.rs
@@ -1,6 +1,7 @@
 //! An implementation for `EnrKey` for `k256::SecretKey`
 
 use super::{EnrKey, EnrPublicKey, SigningError};
+use crate::Key;
 use k256_crate::{
     ecdsa::signature::{DigestVerifier, RandomizedDigestSigner, Signature},
     elliptic_curve::weierstrass::public_key::FromPublicKey,
@@ -36,9 +37,9 @@ impl EnrKey for k256_crate::SecretKey {
         self.try_into().unwrap()
     }
 
-    fn enr_to_public(content: &BTreeMap<String, Vec<u8>>) -> Result<Self::PublicKey, DecoderError> {
+    fn enr_to_public(content: &BTreeMap<Key, Vec<u8>>) -> Result<Self::PublicKey, DecoderError> {
         let pubkey_bytes = content
-            .get(ENR_KEY)
+            .get(ENR_KEY.as_bytes())
             .ok_or_else(|| DecoderError::Custom("Unknown signature"))?;
 
         // should be encoded in compressed form, i.e 33 byte raw secp256k1 public key
@@ -75,7 +76,7 @@ impl EnrPublicKey for k256_crate::PublicKey {
             .to_vec()
     }
 
-    fn enr_key(&self) -> String {
+    fn enr_key(&self) -> Key {
         ENR_KEY.into()
     }
 }

--- a/src/keys/libsecp256k1.rs
+++ b/src/keys/libsecp256k1.rs
@@ -2,6 +2,7 @@
 
 use super::{secp256k1, EnrKey, EnrPublicKey, SigningError};
 use crate::digest;
+use crate::Key;
 use rlp::DecoderError;
 use std::collections::BTreeMap;
 
@@ -30,9 +31,9 @@ impl EnrKey for secp256k1::SecretKey {
     }
 
     /// Decodes the raw bytes of an ENR's content into a public key if possible.
-    fn enr_to_public(content: &BTreeMap<String, Vec<u8>>) -> Result<Self::PublicKey, DecoderError> {
+    fn enr_to_public(content: &BTreeMap<Key, Vec<u8>>) -> Result<Self::PublicKey, DecoderError> {
         let pubkey_bytes = content
-            .get(ENR_KEY)
+            .get(ENR_KEY.as_bytes())
             .ok_or_else(|| DecoderError::Custom("Unknown signature"))?;
         // should be encoded in compressed form, i.e 33 byte raw secp256k1 public key
         secp256k1::PublicKey::parse_slice(
@@ -69,7 +70,7 @@ impl EnrPublicKey for secp256k1::PublicKey {
     }
 
     /// Generates the ENR public key string associated with the secp256k1 key type.
-    fn enr_key(&self) -> String {
+    fn enr_key(&self) -> Key {
         ENR_KEY.into()
     }
 }

--- a/src/keys/mod.rs
+++ b/src/keys/mod.rs
@@ -28,6 +28,7 @@ pub use ed25519_dalek;
 #[cfg(any(feature = "libsecp256k1", doc))]
 pub use secp256k1;
 
+use crate::Key;
 use rlp::DecoderError;
 use std::{
     collections::BTreeMap,
@@ -51,7 +52,7 @@ pub trait EnrKey {
     /// `EnrPublicKey`. It takes the ENR's `BTreeMap` and returns a public key.
     ///
     /// Note: This specifies the supported key schemes for an ENR.
-    fn enr_to_public(content: &BTreeMap<String, Vec<u8>>) -> Result<Self::PublicKey, DecoderError>;
+    fn enr_to_public(content: &BTreeMap<Key, Vec<u8>>) -> Result<Self::PublicKey, DecoderError>;
 }
 
 /// The trait required for a `PublicKey` to verify an ENR record.
@@ -68,7 +69,7 @@ pub trait EnrPublicKey {
 
     /// Returns the ENR key identifier for the public key type. For `secp256k1` keys this
     /// is `secp256k1`.
-    fn enr_key(&self) -> String;
+    fn enr_key(&self) -> Key;
 }
 
 /// An error during signing of a message.

--- a/src/keys/rust_secp256k1.rs
+++ b/src/keys/rust_secp256k1.rs
@@ -1,5 +1,6 @@
 use super::{EnrKey, EnrPublicKey, SigningError};
 use crate::digest;
+use crate::Key;
 use rlp::DecoderError;
 use std::collections::BTreeMap;
 
@@ -25,9 +26,9 @@ impl EnrKey for c_secp256k1::SecretKey {
         Self::PublicKey::from_secret_key(&c_secp256k1::Secp256k1::new(), self)
     }
 
-    fn enr_to_public(content: &BTreeMap<String, Vec<u8>>) -> Result<Self::PublicKey, DecoderError> {
+    fn enr_to_public(content: &BTreeMap<Key, Vec<u8>>) -> Result<Self::PublicKey, DecoderError> {
         let pubkey_bytes = content
-            .get(ENR_KEY)
+            .get(ENR_KEY.as_bytes())
             .ok_or_else(|| DecoderError::Custom("Unknown signature"))?;
         // should be encoded in compressed form, i.e 33 byte raw secp256k1 public key
         c_secp256k1::PublicKey::from_slice(pubkey_bytes)
@@ -54,7 +55,7 @@ impl EnrPublicKey for c_secp256k1::PublicKey {
         self.serialize_uncompressed()[1..].to_vec()
     }
 
-    fn enr_key(&self) -> String {
+    fn enr_key(&self) -> Key {
         ENR_KEY.into()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -464,7 +464,7 @@ impl<K: EnrKey> Enr<K> {
         enr_key: &K,
     ) -> Result<Option<Vec<u8>>, EnrError> {
         // currently only support "v4" identity schemes
-        if key.as_ref() == "id".as_bytes() && value != b"v4" {
+        if key.as_ref() == b"id" && value != b"v4" {
             return Err(EnrError::UnsupportedIdentityScheme);
         }
 
@@ -639,7 +639,7 @@ impl<K: EnrKey> Enr<K> {
                     if let Some(ip) = prev_ip {
                         self.content.insert("ip".into(), ip);
                     } else {
-                        self.content.remove("ip".as_bytes());
+                        self.content.remove(b"ip".as_ref());
                     }
                     if let Some(udp) = prev_port {
                         self.content.insert(port_string, udp);
@@ -651,7 +651,7 @@ impl<K: EnrKey> Enr<K> {
                     if let Some(ip) = prev_ip {
                         self.content.insert("ip6".into(), ip);
                     } else {
-                        self.content.remove("ip6".as_bytes());
+                        self.content.remove(b"ip6".as_ref());
                     }
                     if let Some(udp) = prev_port {
                         self.content.insert(port_v6_string, udp);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -199,6 +199,9 @@ pub use keys::{EnrKey, EnrPublicKey};
 pub use node_id::NodeId;
 use std::marker::PhantomData;
 
+/// The "key" in an ENR record can be arbitrary bytes.
+type Key = Vec<u8>;
+
 const MAX_ENR_SIZE: usize = 300;
 
 /// The ENR, allowing for arbitrary signing algorithms. The default signing algorithm is
@@ -215,7 +218,7 @@ pub struct Enr<K: EnrKey> {
 
     /// Key-value contents of the ENR. A BTreeMap is used to get the keys in sorted order, which is
     /// important for verifying the signature of the ENR.
-    content: BTreeMap<String, Vec<u8>>,
+    content: BTreeMap<Key, Vec<u8>>,
 
     /// The signature of the ENR record, stored as bytes.
     signature: Vec<u8>,
@@ -240,19 +243,19 @@ impl<K: EnrKey> Enr<K> {
     }
 
     /// Reads a custom key from the record if it exists.
-    pub fn get(&self, key: impl Into<String>) -> Option<&Vec<u8>> {
-        self.content.get(&key.into())
+    pub fn get(&self, key: impl AsRef<[u8]>) -> Option<&Vec<u8>> {
+        self.content.get(key.as_ref())
     }
 
     /// Returns an iterator over all key/value pairs in the ENR.
-    pub fn iter(&self) -> impl Iterator<Item = (&String, &Vec<u8>)> {
+    pub fn iter(&self) -> impl Iterator<Item = (&Key, &Vec<u8>)> {
         self.content.iter()
     }
 
     /// Returns the IPv4 address of the ENR record if it is defined.
     #[must_use]
     pub fn ip(&self) -> Option<Ipv4Addr> {
-        if let Some(ip_bytes) = self.content.get("ip") {
+        if let Some(ip_bytes) = self.get("ip") {
             return match ip_bytes.len() {
                 4 => {
                     let mut ip = [0_u8; 4];
@@ -268,7 +271,7 @@ impl<K: EnrKey> Enr<K> {
     /// Returns the IPv6 address of the ENR record if it is defined.
     #[must_use]
     pub fn ip6(&self) -> Option<Ipv6Addr> {
-        if let Some(ip_bytes) = self.content.get("ip6") {
+        if let Some(ip_bytes) = self.get("ip6") {
             return match ip_bytes.len() {
                 16 => {
                     let mut ip = [0_u8; 16];
@@ -284,7 +287,7 @@ impl<K: EnrKey> Enr<K> {
     /// The `id` of ENR record if it is defined.
     #[must_use]
     pub fn id(&self) -> Option<String> {
-        if let Some(id_bytes) = self.content.get("id") {
+        if let Some(id_bytes) = self.get("id") {
             return Some(String::from_utf8_lossy(id_bytes).to_string());
         }
         None
@@ -293,7 +296,7 @@ impl<K: EnrKey> Enr<K> {
     /// The TCP port of ENR record if it is defined.
     #[must_use]
     pub fn tcp(&self) -> Option<u16> {
-        if let Some(tcp_bytes) = self.content.get("tcp") {
+        if let Some(tcp_bytes) = self.get("tcp") {
             if tcp_bytes.len() <= 2 {
                 let mut tcp = [0_u8; 2];
                 tcp[2 - tcp_bytes.len()..].copy_from_slice(tcp_bytes);
@@ -306,7 +309,7 @@ impl<K: EnrKey> Enr<K> {
     /// The IPv6-specific TCP port of ENR record if it is defined.
     #[must_use]
     pub fn tcp6(&self) -> Option<u16> {
-        if let Some(tcp_bytes) = self.content.get("tcp6") {
+        if let Some(tcp_bytes) = self.get("tcp6") {
             if tcp_bytes.len() <= 2 {
                 let mut tcp = [0_u8; 2];
                 tcp[2 - tcp_bytes.len()..].copy_from_slice(tcp_bytes);
@@ -319,7 +322,7 @@ impl<K: EnrKey> Enr<K> {
     /// The UDP port of ENR record if it is defined.
     #[must_use]
     pub fn udp(&self) -> Option<u16> {
-        if let Some(udp_bytes) = self.content.get("udp") {
+        if let Some(udp_bytes) = self.get("udp") {
             if udp_bytes.len() <= 2 {
                 let mut udp = [0_u8; 2];
                 udp[2 - udp_bytes.len()..].copy_from_slice(udp_bytes);
@@ -332,7 +335,7 @@ impl<K: EnrKey> Enr<K> {
     /// The IPv6-specific UDP port of ENR record if it is defined.
     #[must_use]
     pub fn udp6(&self) -> Option<u16> {
-        if let Some(udp_bytes) = self.content.get("udp6") {
+        if let Some(udp_bytes) = self.get("udp6") {
             if udp_bytes.len() <= 2 {
                 let mut udp = [0_u8; 2];
                 udp[2 - udp_bytes.len()..].copy_from_slice(udp_bytes);
@@ -342,7 +345,7 @@ impl<K: EnrKey> Enr<K> {
         None
     }
 
-    /// Provides a socket (based on the UDP port), if the IP and UDP fields are specified.
+    /// Provides a socket (based on the UDP port), if the IPv4 and UDP fields are specified.
     #[must_use]
     pub fn udp_socket(&self) -> Option<SocketAddr> {
         if let Some(ip) = self.ip() {
@@ -350,6 +353,12 @@ impl<K: EnrKey> Enr<K> {
                 return Some(SocketAddr::new(IpAddr::V4(ip), udp));
             }
         }
+        None
+    }
+
+    /// Provides a socket (based on the UDP port), if the IPv4 and UDP fields are specified.
+    #[must_use]
+    pub fn udp6_socket(&self) -> Option<SocketAddr> {
         if let Some(ip6) = self.ip6() {
             if let Some(udp6) = self.udp6() {
                 return Some(SocketAddr::new(IpAddr::V6(ip6), udp6));
@@ -358,7 +367,7 @@ impl<K: EnrKey> Enr<K> {
         None
     }
 
-    /// Provides a socket (based on the TCP port), if the IP and UDP fields are specified.
+    /// Provides a socket (based on the TCP port), if the IP and TCP fields are specified.
     #[must_use]
     pub fn tcp_socket(&self) -> Option<SocketAddr> {
         if let Some(ip) = self.ip() {
@@ -366,6 +375,12 @@ impl<K: EnrKey> Enr<K> {
                 return Some(SocketAddr::new(IpAddr::V4(ip), tcp));
             }
         }
+        None
+    }
+
+    /// Provides a socket (based on the TCP port), if the IPv6 and TCP6 fields are specified.
+    #[must_use]
+    pub fn tcp6_socket(&self) -> Option<SocketAddr> {
         if let Some(ip6) = self.ip6() {
             if let Some(tcp6) = self.tcp6() {
                 return Some(SocketAddr::new(IpAddr::V6(ip6), tcp6));
@@ -444,16 +459,16 @@ impl<K: EnrKey> Enr<K> {
     /// Returns the previous value in the record if it exists.
     pub fn insert(
         &mut self,
-        key: &str,
+        key: impl AsRef<[u8]>,
         value: Vec<u8>,
         enr_key: &K,
     ) -> Result<Option<Vec<u8>>, EnrError> {
         // currently only support "v4" identity schemes
-        if key == "id" && value != b"v4" {
+        if key.as_ref() == "id".as_bytes() && value != b"v4" {
             return Err(EnrError::UnsupportedIdentityScheme);
         }
 
-        let previous_value = self.content.insert(key.into(), value);
+        let previous_value = self.content.insert(key.as_ref().to_vec(), value);
         // add the new public key
         let public_key = enr_key.public();
         let previous_key = self
@@ -471,9 +486,9 @@ impl<K: EnrKey> Enr<K> {
             }
             // revert the content
             if let Some(prev_value) = previous_value {
-                self.content.insert(key.into(), prev_value);
+                self.content.insert(key.as_ref().to_vec(), prev_value);
             } else {
-                self.content.remove(key);
+                self.content.remove(key.as_ref());
             }
             return Err(EnrError::ExceedsMaxSize);
         }
@@ -585,7 +600,7 @@ impl<K: EnrKey> Enr<K> {
 
     /// Helper function for `set_tcp_socket()` and `set_udp_socket`.
     fn set_socket(&mut self, socket: SocketAddr, key: &K, is_tcp: bool) -> Result<(), EnrError> {
-        let (port_string, port_v6_string): (String, String) = if is_tcp {
+        let (port_string, port_v6_string): (Key, Key) = if is_tcp {
             ("tcp".into(), "tcp6".into())
         } else {
             ("udp".into(), "udp6".into())
@@ -624,7 +639,7 @@ impl<K: EnrKey> Enr<K> {
                     if let Some(ip) = prev_ip {
                         self.content.insert("ip".into(), ip);
                     } else {
-                        self.content.remove(&String::from("ip"));
+                        self.content.remove("ip".as_bytes());
                     }
                     if let Some(udp) = prev_port {
                         self.content.insert(port_string, udp);
@@ -636,7 +651,7 @@ impl<K: EnrKey> Enr<K> {
                     if let Some(ip) = prev_ip {
                         self.content.insert("ip6".into(), ip);
                     } else {
-                        self.content.remove(&String::from("ip6"));
+                        self.content.remove("ip6".as_bytes());
                     }
                     if let Some(udp) = prev_port {
                         self.content.insert(port_v6_string, udp);
@@ -821,18 +836,16 @@ impl<K: EnrKey> rlp::Decodable for Enr<K> {
         let seq = u64::from_be_bytes(seq);
 
         let mut content = BTreeMap::new();
-        let mut prev: Option<String> = None;
+        let mut prev: Option<Key> = None;
         for _ in 0..decoded_list.len() / 2 {
-            let key = decoded_list.remove(0).data()?;
+            let key = decoded_list.remove(0).data()?.to_vec();
             let value = decoded_list.remove(0).data()?;
 
-            let key = String::from_utf8_lossy(key);
-            // TODO: add tests for this error case
-            if prev.is_some() && prev >= Some(key.to_string()) {
+            if prev.is_some() && prev.as_ref() >= Some(&key) {
                 return Err(DecoderError::Custom("Unsorted keys"));
             }
-            prev = Some(key.to_string());
-            content.insert(key.to_string(), value.into());
+            prev = Some(key.clone());
+            content.insert(key, value.into());
         }
 
         // verify we know the signature type


### PR DESCRIPTION
## Description

This PR generalises the keys stored in ENR records to be arbitrary byte sequences rather than utf8 strings. 

The API are now changed slightly as users wishing to read keys must now decode the bytes to a readable format manually. 


#### Bonus 
This also remove previous ipv4 bias allowing better handling of ipv6/ipv4 dual stack implementations. 