### PR TITLE
Replace tiny-keccak with sha3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,11 +21,10 @@ hex = "0.4.2"
 log = "0.4.8"
 rand = "0.7.3"
 rlp = "0.4.5"
-tiny-keccak = { version = "2.0.2", features = ["keccak"] }
 zeroize = "1.1.0"
 libsecp256k1 = { version = "0.3.5", optional = true }
 ecdsa = { version = "0.8", optional = true }
-sha3 = { version = "0.9", optional = true }
+sha3 = "0.9"
 k256-crate = { package = "k256", version = "0.5", features = ["ecdsa"], optional = true }
 serde = { version = "1.0.110", optional = true }
 ed25519-dalek = { version = "1.0.0-pre.4", optional = true }
@@ -38,7 +37,7 @@ c-secp256k1 = { package = "secp256k1", features = ["rand-std"], version = "0.17.
 default = ["serde", "libsecp256k1" ]
 ed25519 = ["ed25519-dalek"]
 rust-secp256k1 = ["c-secp256k1"]
-k256 = ["k256-crate", "ecdsa", "sha3"]
+k256 = ["k256-crate", "ecdsa"]
 
 [lib]
 name = "enr"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -178,10 +178,10 @@ mod node_id;
 use log::debug;
 use rlp::{DecoderError, Rlp, RlpStream};
 use std::collections::BTreeMap;
-use tiny_keccak::{Hasher, Keccak};
 
 #[cfg(feature = "serde")]
 use serde::{de::Error, Deserialize, Deserializer, Serialize, Serializer};
+use sha3::{Digest, Keccak256};
 use std::{
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
     str::FromStr,
@@ -887,9 +887,7 @@ pub enum EnrError {
 
 pub(crate) fn digest(b: &[u8]) -> [u8; 32] {
     let mut output = [0_u8; 32];
-    let mut hasher = Keccak::v256();
-    hasher.update(b);
-    hasher.finalize(&mut output);
+    output.copy_from_slice(&Keccak256::digest(b));
     output
 }
 


### PR DESCRIPTION
Already used for `k256` keys, might as well use for everything