### PR TITLE
Use ECDSA APIs from k256

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ rlp = "0.4.5"
 tiny-keccak = { version = "2.0.2", features = ["keccak"] }
 zeroize = "1.1.0"
 libsecp256k1 = { version = "0.3.5", optional = true }
-ecdsa = { version = "0.8", optional = true }
 sha3 = { version = "0.9", optional = true }
 k256-crate = { package = "k256", version = "0.5", features = ["ecdsa"], optional = true }
 serde = { version = "1.0.110", optional = true }
@@ -38,7 +37,7 @@ c-secp256k1 = { package = "secp256k1", features = ["rand-std"], version = "0.17.
 default = ["serde", "libsecp256k1" ]
 ed25519 = ["ed25519-dalek"]
 rust-secp256k1 = ["c-secp256k1"]
-k256 = ["k256-crate", "ecdsa", "sha3"]
+k256 = ["k256-crate", "sha3"]
 
 [lib]
 name = "enr"

--- a/src/keys/k256.rs
+++ b/src/keys/k256.rs
@@ -61,7 +61,7 @@ impl EnrPublicKey for VerifyKey {
     }
 
     fn encode_uncompressed(&self) -> Vec<u8> {
-        EncodedPoint::from(self).decompress().unwrap().to_bytes()[1..].to_vec()
+        EncodedPoint::from(self).to_untagged_bytes().unwrap().to_vec()
     }
 
     fn enr_key(&self) -> Key {

--- a/src/keys/k256.rs
+++ b/src/keys/k256.rs
@@ -61,7 +61,10 @@ impl EnrPublicKey for VerifyKey {
     }
 
     fn encode_uncompressed(&self) -> Vec<u8> {
-        EncodedPoint::from(self).to_untagged_bytes().unwrap().to_vec()
+        EncodedPoint::from(self)
+            .to_untagged_bytes()
+            .unwrap()
+            .to_vec()
     }
 
     fn enr_key(&self) -> Key {

--- a/src/keys/k256.rs
+++ b/src/keys/k256.rs
@@ -1,9 +1,14 @@
-//! An implementation for `EnrKey` for `k256::SecretKey`
+//! An implementation for `EnrKey` for `k256::ecdsa::SigningKey`
 
 use super::{EnrKey, EnrPublicKey, SigningError};
 use crate::Key;
-use ecdsa::elliptic_curve::sec1::{FromEncodedPoint, ToEncodedPoint};
-use k256_crate::ecdsa::signature::{DigestVerifier, RandomizedDigestSigner, Signature};
+use k256_crate::{
+    ecdsa::{
+        signature::{DigestVerifier, RandomizedDigestSigner, Signature as _},
+        Signature, SigningKey, VerifyKey,
+    },
+    EncodedPoint,
+};
 use rand::rngs::OsRng;
 use rlp::DecoderError;
 use sha3::{Digest, Keccak256};
@@ -12,24 +17,21 @@ use std::{collections::BTreeMap, convert::TryFrom};
 /// The ENR key that stores the public key in the ENR record.
 pub const ENR_KEY: &str = "secp256k1";
 
-type Signer = ecdsa::SigningKey<k256_crate::Secp256k1>;
-type Verifier = ecdsa::VerifyKey<k256_crate::Secp256k1>;
-
-impl EnrKey for k256_crate::SecretKey {
-    type PublicKey = k256_crate::EncodedPoint;
+impl EnrKey for SigningKey {
+    type PublicKey = VerifyKey;
 
     fn sign_v4(&self, msg: &[u8]) -> Result<Vec<u8>, SigningError> {
         // take a keccak256 hash then sign.
         let digest = Keccak256::new().chain(msg);
-        let signature: k256_crate::ecdsa::Signature = Signer::new(self.to_bytes().as_slice())
-            .map_err(|_| SigningError::new("failed to create signer"))?
-            .sign_digest_with_rng(&mut OsRng, digest);
+        let signature: Signature = self
+            .try_sign_digest_with_rng(&mut OsRng, digest)
+            .map_err(|_| SigningError::new("failed to sign"))?;
 
         Ok(signature.as_bytes().to_vec())
     }
 
     fn public(&self) -> Self::PublicKey {
-        k256_crate::EncodedPoint::from_secret_key(self, false)
+        self.verify_key()
     }
 
     fn enr_to_public(content: &BTreeMap<Key, Vec<u8>>) -> Result<Self::PublicKey, DecoderError> {
@@ -38,35 +40,28 @@ impl EnrKey for k256_crate::SecretKey {
             .ok_or_else(|| DecoderError::Custom("Unknown signature"))?;
 
         // should be encoded in compressed form, i.e 33 byte raw secp256k1 public key
-        Ok(k256_crate::EncodedPoint::from_bytes(pubkey_bytes)
+        Ok(VerifyKey::new(pubkey_bytes)
             .map_err(|_| DecoderError::Custom("Invalid Secp256k1 Signature"))?)
     }
 }
 
-impl EnrPublicKey for k256_crate::EncodedPoint {
+impl EnrPublicKey for VerifyKey {
     fn verify_v4(&self, msg: &[u8], sig: &[u8]) -> bool {
-        let digest = Keccak256::new().chain(msg);
         if let Ok(sig) = k256_crate::ecdsa::Signature::try_from(sig) {
-            if let Ok(verifier) = Verifier::new(self.as_bytes()) {
-                if verifier.verify_digest(digest, &sig).is_ok() {
-                    return true;
-                }
-            }
+            return self
+                .verify_digest(Keccak256::new().chain(msg), &sig)
+                .is_ok();
         }
         false
     }
 
     fn encode(&self) -> Vec<u8> {
         // serialize in compressed form: 33 bytes
-        self.compress().as_bytes().to_vec()
+        self.to_bytes().to_vec()
     }
 
     fn encode_uncompressed(&self) -> Vec<u8> {
-        k256_crate::AffinePoint::from_encoded_point(self)
-            .unwrap()
-            .to_encoded_point(false)
-            .as_bytes()[1..]
-            .to_vec()
+        EncodedPoint::from(self).decompress().unwrap().to_bytes()[1..].to_vec()
     }
 
     fn enr_key(&self) -> Key {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -932,7 +932,7 @@ mod tests {
             hex::decode("03ca634cae0d49acb401d8a4c6b6fe8c55b70d115bf400769cc1400f3258cd3138")
                 .unwrap();
 
-        let enr = rlp::decode::<Enr<k256_crate::SecretKey>>(&valid_record).unwrap();
+        let enr = rlp::decode::<Enr<k256_crate::ecdsa::SigningKey>>(&valid_record).unwrap();
 
         let pubkey = enr.public_key().encode();
 
@@ -985,7 +985,7 @@ mod tests {
             hex::decode("a448f24c6d18e575453db13171562b71999873db5b286df957af199ec94617f7")
                 .unwrap();
 
-        let enr = text.parse::<Enr<k256_crate::SecretKey>>().unwrap();
+        let enr = text.parse::<Enr<k256_crate::ecdsa::SigningKey>>().unwrap();
         let pubkey = enr.public_key().encode();
         assert_eq!(enr.ip(), Some(Ipv4Addr::new(127, 0, 0, 1)));
         assert_eq!(enr.ip6(), None);
@@ -1116,7 +1116,7 @@ mod tests {
     #[cfg(feature = "k256")]
     #[test]
     fn test_encode_decode_k256() {
-        let key = k256_crate::SecretKey::random(&mut rand::rngs::OsRng);
+        let key = k256_crate::ecdsa::SigningKey::random(&mut rand::rngs::OsRng);
         let ip = Ipv4Addr::new(127, 0, 0, 1);
         let tcp = 3000;
 


### PR DESCRIPTION
k256 v0.5 has introduced new ECDSA APIs which are a lot more straightforward to use. This PR replaces implementation of `EnrKey` and `EnrPublicKey` for low-level primitives with these, which are more aligned with our use case.

My gratitude to @tarcieri for guidance on correct API usage.