### PR TITLE
Fix secp256k1 verification

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -137,8 +137,8 @@ impl<K: EnrKey> EnrBuilder<K> {
         }
 
         // Sanitize all data, ensuring all RLP data is correctly formatted.
-        for (key, value) in self.content.iter() {
-            if let Err(_) = rlp::Rlp::new(value).data() {
+        for (key, value) in &self.content {
+            if rlp::Rlp::new(value).data().is_err() {
                 return Err(EnrError::InvalidRLPData(
                     String::from_utf8_lossy(key).into(),
                 ));

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -12,6 +12,7 @@ pub struct EnrBuilder<K: EnrKey> {
     seq: u64,
 
     /// The key-value pairs for the ENR record.
+    /// Values are stored as RLP encoded bytes.
     content: BTreeMap<Key, Vec<u8>>,
 
     /// Pins the generic key types.
@@ -38,8 +39,13 @@ impl<K: EnrKey> EnrBuilder<K> {
     }
 
     /// Adds an arbitrary key-value to the `ENRBuilder`.
-    pub fn add_value(&mut self, key: impl AsRef<[u8]>, value: Vec<u8>) -> &mut Self {
-        self.content.insert(key.as_ref().to_vec(), value);
+    pub fn add_value(&mut self, key: impl AsRef<[u8]>, value: &[u8]) -> &mut Self {
+        self.add_value_rlp(key, rlp::encode(&value))
+    }
+
+    /// Adds an arbitrary key-value where the value is raw RLP encoded bytes.
+    pub fn add_value_rlp(&mut self, key: impl AsRef<[u8]>, rlp: Vec<u8>) -> &mut Self {
+        self.content.insert(key.as_ref().to_vec(), rlp);
         self
     }
 
@@ -47,10 +53,10 @@ impl<K: EnrKey> EnrBuilder<K> {
     pub fn ip(&mut self, ip: IpAddr) -> &mut Self {
         match ip {
             IpAddr::V4(addr) => {
-                self.content.insert(b"ip".to_vec(), addr.octets().to_vec());
+                self.add_value("ip", &addr.octets());
             }
             IpAddr::V6(addr) => {
-                self.content.insert(b"ip6".to_vec(), addr.octets().to_vec());
+                self.add_value("ip6", &addr.octets());
             }
         }
         self
@@ -62,36 +68,32 @@ impl<K: EnrKey> EnrBuilder<K> {
 
     /// Adds an `Id` field to the `ENRBuilder`.
     pub fn id(&mut self, id: &str) -> &mut Self {
-        self.content.insert("id".into(), id.as_bytes().to_vec());
+        self.add_value("id", &id.as_bytes());
         self
     }
     */
 
     /// Adds a `tcp` field to the `ENRBuilder`.
     pub fn tcp(&mut self, tcp: u16) -> &mut Self {
-        self.content
-            .insert("tcp".into(), tcp.to_be_bytes().to_vec());
+        self.add_value("tcp", &tcp.to_be_bytes());
         self
     }
 
     /// Adds a `tcp6` field to the `ENRBuilder`.
     pub fn tcp6(&mut self, tcp: u16) -> &mut Self {
-        self.content
-            .insert("tcp6".into(), tcp.to_be_bytes().to_vec());
+        self.add_value("tcp6", &tcp.to_be_bytes());
         self
     }
 
     /// Adds a `udp` field to the `ENRBuilder`.
     pub fn udp(&mut self, udp: u16) -> &mut Self {
-        self.content
-            .insert("udp".into(), udp.to_be_bytes().to_vec());
+        self.add_value("udp", &udp.to_be_bytes());
         self
     }
 
     /// Adds a `udp6` field to the `ENRBuilder`.
     pub fn udp6(&mut self, udp: u16) -> &mut Self {
-        self.content
-            .insert("udp6".into(), udp.to_be_bytes().to_vec());
+        self.add_value("udp6", &udp.to_be_bytes());
         self
     }
 
@@ -102,7 +104,8 @@ impl<K: EnrKey> EnrBuilder<K> {
         stream.append(&self.seq);
         for (k, v) in &self.content {
             stream.append(k);
-            stream.append(v);
+            // The values are stored as raw RLP encoded bytes
+            stream.append_raw(v, 1);
         }
         stream.drain()
     }
@@ -120,7 +123,7 @@ impl<K: EnrKey> EnrBuilder<K> {
 
     /// Adds a public key to the ENR builder.
     fn add_public_key(&mut self, key: &K::PublicKey) {
-        self.add_value(key.enr_key(), key.encode());
+        self.add_value(key.enr_key(), &key.encode());
     }
 
     /// Constructs an ENR from the `EnrBuilder`.
@@ -133,8 +136,17 @@ impl<K: EnrKey> EnrBuilder<K> {
             return Err(EnrError::UnsupportedIdentityScheme);
         }
 
-        self.content
-            .insert("id".into(), self.id.as_bytes().to_vec());
+        // Sanitize all data, ensuring all RLP data is correctly formatted.
+        for (key, value) in self.content.iter() {
+            if let Err(_) = rlp::Rlp::new(value).data() {
+                return Err(EnrError::InvalidRLPData(
+                    String::from_utf8_lossy(key).into(),
+                ));
+            }
+        }
+
+        let id_bytes = &self.id.as_bytes().to_vec();
+        self.add_value("id", id_bytes);
 
         self.add_public_key(&key.public());
         let rlp_content = self.rlp_content();

--- a/src/keys/ed25519.rs
+++ b/src/keys/ed25519.rs
@@ -30,6 +30,10 @@ impl EnrKey for ed25519::Keypair {
         let pubkey_bytes = content
             .get(ENR_KEY.as_bytes())
             .ok_or_else(|| DecoderError::Custom("Unknown signature"))?;
+
+        // Decode the RLP
+        let pubkey_bytes = rlp::Rlp::new(pubkey_bytes).data()?;
+
         ed25519::PublicKey::from_bytes(pubkey_bytes)
             .map_err(|_| DecoderError::Custom("Invalid ed25519 Signature"))
     }

--- a/src/keys/k256.rs
+++ b/src/keys/k256.rs
@@ -39,6 +39,9 @@ impl EnrKey for SigningKey {
             .get(ENR_KEY.as_bytes())
             .ok_or_else(|| DecoderError::Custom("Unknown signature"))?;
 
+        // Decode the RLP
+        let pubkey_bytes = rlp::Rlp::new(pubkey_bytes).data()?;
+
         // should be encoded in compressed form, i.e 33 byte raw secp256k1 public key
         Ok(VerifyKey::new(pubkey_bytes)
             .map_err(|_| DecoderError::Custom("Invalid Secp256k1 Signature"))?)

--- a/src/keys/libsecp256k1.rs
+++ b/src/keys/libsecp256k1.rs
@@ -35,6 +35,10 @@ impl EnrKey for secp256k1::SecretKey {
         let pubkey_bytes = content
             .get(ENR_KEY.as_bytes())
             .ok_or_else(|| DecoderError::Custom("Unknown signature"))?;
+
+        // Decode the RLP
+        let pubkey_bytes = rlp::Rlp::new(pubkey_bytes).data()?;
+
         // should be encoded in compressed form, i.e 33 byte raw secp256k1 public key
         secp256k1::PublicKey::parse_slice(
             pubkey_bytes,

--- a/src/keys/libsecp256k1.rs
+++ b/src/keys/libsecp256k1.rs
@@ -48,11 +48,12 @@ impl EnrPublicKey for secp256k1::PublicKey {
     /// Verify a raw message, given a public key for the v4 identity scheme.
     fn verify_v4(&self, msg: &[u8], sig: &[u8]) -> bool {
         let msg = digest(msg);
-        secp256k1::Signature::parse_slice(sig)
-            .and_then(|sig| {
-                secp256k1::Message::parse_slice(&msg).map(|m| secp256k1::verify(&m, &sig, self))
-            })
-            .is_ok()
+        if let Ok(sig) = secp256k1::Signature::parse_slice(sig) {
+            if let Ok(msg) = secp256k1::Message::parse_slice(&msg) {
+                return secp256k1::verify(&msg, &sig, self);
+            }
+        }
+        false
     }
 
     /// Encodes the public key into compressed form, if possible.

--- a/src/keys/rust_secp256k1.rs
+++ b/src/keys/rust_secp256k1.rs
@@ -31,6 +31,8 @@ impl EnrKey for c_secp256k1::SecretKey {
             .get(ENR_KEY.as_bytes())
             .ok_or_else(|| DecoderError::Custom("Unknown signature"))?;
         // should be encoded in compressed form, i.e 33 byte raw secp256k1 public key
+        // Decode the RLP
+        let pubkey_bytes = rlp::Rlp::new(pubkey_bytes).data()?;
         c_secp256k1::PublicKey::from_slice(pubkey_bytes)
             .map_err(|_| DecoderError::Custom("Invalid Secp256k1 Signature"))
     }

--- a/src/keys/rust_secp256k1.rs
+++ b/src/keys/rust_secp256k1.rs
@@ -39,12 +39,14 @@ impl EnrKey for c_secp256k1::SecretKey {
 impl EnrPublicKey for c_secp256k1::PublicKey {
     fn verify_v4(&self, msg: &[u8], sig: &[u8]) -> bool {
         let msg = digest(msg);
-        c_secp256k1::Signature::from_compact(sig)
-            .and_then(|sig| {
-                c_secp256k1::Message::from_slice(&msg)
-                    .map(|m| c_secp256k1::Secp256k1::new().verify(&m, &sig, self))
-            })
-            .is_ok()
+        if let Ok(sig) = c_secp256k1::Signature::from_compact(sig) {
+            if let Ok(msg) = c_secp256k1::Message::from_slice(&msg) {
+                return c_secp256k1::Secp256k1::new()
+                    .verify(&msg, &sig, self)
+                    .is_ok();
+            }
+        }
+        false
     }
 
     fn encode(&self) -> Vec<u8> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -848,7 +848,6 @@ impl<K: EnrKey> rlp::Decodable for Enr<K> {
             return Err(DecoderError::RlpExpectedToBeList);
         }
 
-        dbg!(hex::encode(rlp.as_raw()));
         let mut decoded_list: Vec<Rlp> = rlp.iter().collect();
 
         if decoded_list.is_empty() || decoded_list.len() % 2 != 0 {
@@ -879,10 +878,6 @@ impl<K: EnrKey> rlp::Decodable for Enr<K> {
             let _ = item.data()?;
             let value = item.as_raw();
 
-            dbg!(String::from_utf8_lossy(&key));
-            dbg!(hex::encode(&key));
-            dbg!(hex::encode(value));
-
             if prev.is_some() && prev.as_ref() >= Some(&key) {
                 return Err(DecoderError::Custom("Unsorted keys"));
             }
@@ -903,8 +898,6 @@ impl<K: EnrKey> rlp::Decodable for Enr<K> {
             content,
             phantom: PhantomData,
         };
-
-        dbg!(hex::encode(&enr.rlp_content()));
 
         // verify the signature before returning
         // if the public key is of an unknown type, this will fail.
@@ -1224,13 +1217,7 @@ mod tests {
             builder.build(&key).unwrap()
         };
 
-        println!("{:?}", enr.id());
-        if let Some(v) = enr.get("secp256k1") {
-            dbg!(hex::encode(v));
-        }
-
         if let Err(e) = enr.insert("random", Vec::new(), &key) {
-            println!("{:?}", e);
             panic!(e);
         }
         assert!(enr.verify());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,7 +119,7 @@
 //! assert_eq!(decoded_enr.ip(), Some("192.168.0.1".parse().unwrap()));
 //! assert_eq!(decoded_enr.id(), Some("v4".into()));
 //! assert_eq!(decoded_enr.tcp(), Some(8001));
-//! assert_eq!(decoded_enr.get("custom_key"), Some(&vec![0,0,1]));
+//! assert_eq!(decoded_enr.get("custom_key"), Some(vec![0,0,1].as_slice()));
 //! ```
 //!
 //! ### Encoding/Decoding ENR's of various key types
@@ -218,6 +218,7 @@ pub struct Enr<K: EnrKey> {
 
     /// Key-value contents of the ENR. A BTreeMap is used to get the keys in sorted order, which is
     /// important for verifying the signature of the ENR.
+    /// Everything is stored as raw RLP bytes.
     content: BTreeMap<Key, Vec<u8>>,
 
     /// The signature of the ENR record, stored as bytes.
@@ -243,7 +244,16 @@ impl<K: EnrKey> Enr<K> {
     }
 
     /// Reads a custom key from the record if it exists.
-    pub fn get(&self, key: impl AsRef<[u8]>) -> Option<&Vec<u8>> {
+    pub fn get(&self, key: impl AsRef<[u8]>) -> Option<&[u8]> {
+        self.get_raw_rlp(key).map(|rlp_data| {
+            rlp::Rlp::new(rlp_data)
+                .data()
+                .expect("All data is sanitized")
+        })
+    }
+
+    /// Reads a custom key from the record if it exists as raw RLP bytes.
+    pub fn get_raw_rlp(&self, key: impl AsRef<[u8]>) -> Option<&Vec<u8>> {
         self.content.get(key.as_ref())
     }
 
@@ -463,6 +473,19 @@ impl<K: EnrKey> Enr<K> {
         value: Vec<u8>,
         enr_key: &K,
     ) -> Result<Option<Vec<u8>>, EnrError> {
+        self.insert_raw_rlp(key, rlp::encode(&value), enr_key)
+    }
+
+    /// Adds or modifies a key/value to the ENR record. A `EnrKey` is required to re-sign the record once
+    /// modified. The value here is interpreted as raw RLP data.
+    ///
+    /// Returns the previous value in the record if it exists.
+    pub fn insert_raw_rlp(
+        &mut self,
+        key: impl AsRef<[u8]>,
+        value: Vec<u8>,
+        enr_key: &K,
+    ) -> Result<Option<Vec<u8>>, EnrError> {
         // currently only support "v4" identity schemes
         if key.as_ref() == b"id" && value != b"v4" {
             return Err(EnrError::UnsupportedIdentityScheme);
@@ -473,7 +496,7 @@ impl<K: EnrKey> Enr<K> {
         let public_key = enr_key.public();
         let previous_key = self
             .content
-            .insert(public_key.enr_key(), public_key.encode());
+            .insert(public_key.enr_key(), rlp::encode(&public_key.encode()));
 
         // check the size of the record
         if self.size() > MAX_ENR_SIZE {
@@ -505,7 +528,7 @@ impl<K: EnrKey> Enr<K> {
         self.node_id = NodeId::from(enr_key.public());
 
         if self.size() > MAX_ENR_SIZE {
-            // incase the signature size changes, inform the user the size has exceeded the maximum
+            // in case the signature size changes, inform the user the size has exceeded the maximum
             return Err(EnrError::ExceedsMaxSize);
         }
 
@@ -608,21 +631,27 @@ impl<K: EnrKey> Enr<K> {
 
         let (prev_ip, prev_port) = match socket.ip() {
             IpAddr::V4(addr) => (
-                self.content.insert("ip".into(), addr.octets().to_vec()),
                 self.content
-                    .insert(port_string.clone(), socket.port().to_be_bytes().to_vec()),
+                    .insert("ip".into(), rlp::encode(&addr.octets().to_vec())),
+                self.content.insert(
+                    port_string.clone(),
+                    rlp::encode(&socket.port().to_be_bytes().to_vec()),
+                ),
             ),
             IpAddr::V6(addr) => (
-                self.content.insert("ip6".into(), addr.octets().to_vec()),
                 self.content
-                    .insert(port_v6_string.clone(), socket.port().to_be_bytes().to_vec()),
+                    .insert("ip6".into(), rlp::encode(&addr.octets().to_vec())),
+                self.content.insert(
+                    port_v6_string.clone(),
+                    rlp::encode(&socket.port().to_be_bytes().to_vec()),
+                ),
             ),
         };
 
         let public_key = key.public();
         let previous_key = self
             .content
-            .insert(public_key.enr_key(), public_key.encode());
+            .insert(public_key.enr_key(), rlp::encode(&public_key.encode()));
 
         // check the size and revert on failure
         if self.size() > MAX_ENR_SIZE {
@@ -692,8 +721,10 @@ impl<K: EnrKey> Enr<K> {
         stream.begin_list(self.content.len() * 2 + 1);
         stream.append(&self.seq);
         for (k, v) in &self.content {
+            // Keys are bytes
             stream.append(k);
-            stream.append(v);
+            // Values are raw RLP encoded data
+            stream.append_raw(v, 1);
         }
         stream.drain()
     }
@@ -802,8 +833,10 @@ impl<K: EnrKey> rlp::Encodable for Enr<K> {
         s.append(&self.seq);
         // must use rlp_content to preserve ordering.
         for (k, v) in &self.content {
+            // Keys are byte data
             s.append(k);
-            s.append(v);
+            // Values are raw RLP encoded data
+            s.append_raw(v, 1);
         }
     }
 }
@@ -815,6 +848,7 @@ impl<K: EnrKey> rlp::Decodable for Enr<K> {
             return Err(DecoderError::RlpExpectedToBeList);
         }
 
+        dbg!(hex::encode(rlp.as_raw()));
         let mut decoded_list: Vec<Rlp> = rlp.iter().collect();
 
         if decoded_list.is_empty() || decoded_list.len() % 2 != 0 {
@@ -839,7 +873,15 @@ impl<K: EnrKey> rlp::Decodable for Enr<K> {
         let mut prev: Option<Key> = None;
         for _ in 0..decoded_list.len() / 2 {
             let key = decoded_list.remove(0).data()?.to_vec();
-            let value = decoded_list.remove(0).data()?;
+            let item = decoded_list.remove(0);
+
+            // Sanitize the data
+            let _ = item.data()?;
+            let value = item.as_raw();
+
+            dbg!(String::from_utf8_lossy(&key));
+            dbg!(hex::encode(&key));
+            dbg!(hex::encode(value));
 
             if prev.is_some() && prev.as_ref() >= Some(&key) {
                 return Err(DecoderError::Custom("Unsorted keys"));
@@ -862,6 +904,8 @@ impl<K: EnrKey> rlp::Decodable for Enr<K> {
             phantom: PhantomData,
         };
 
+        dbg!(hex::encode(&enr.rlp_content()));
+
         // verify the signature before returning
         // if the public key is of an unknown type, this will fail.
         // An ENR record will always have a valid public-key and therefore node-id
@@ -883,6 +927,8 @@ pub enum EnrError {
     SigningError,
     /// The identity scheme is not supported.
     UnsupportedIdentityScheme,
+    /// The entered RLP data is invalid.
+    InvalidRLPData(String),
 }
 
 pub(crate) fn digest(b: &[u8]) -> [u8; 32] {
@@ -1016,6 +1062,7 @@ mod tests {
         assert_eq!(enr.seq(), 40);
         assert_eq!(enr.signature(), &signature[..]);
         assert_eq!(enr.public_key().encode(), expected_pubkey);
+
         assert!(enr.verify());
     }
 
@@ -1177,7 +1224,15 @@ mod tests {
             builder.build(&key).unwrap()
         };
 
-        assert!(enr.insert("random", Vec::new(), &key).is_ok());
+        println!("{:?}", enr.id());
+        if let Some(v) = enr.get("secp256k1") {
+            dbg!(hex::encode(v));
+        }
+
+        if let Err(e) = enr.insert("random", Vec::new(), &key) {
+            println!("{:?}", e);
+            panic!(e);
+        }
         assert!(enr.verify());
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,7 +108,7 @@
 //!
 //! enr.set_tcp(8001, &key);
 //! // set a custom key
-//! enr.insert("custom_key", vec![0,0,1], &key);
+//! enr.insert("custom_key", &vec![0,0,1], &key);
 //!
 //! // encode to base64
 //! let base_64_string = enr.to_base64();
@@ -470,7 +470,7 @@ impl<K: EnrKey> Enr<K> {
     pub fn insert(
         &mut self,
         key: impl AsRef<[u8]>,
-        value: Vec<u8>,
+        value: &[u8],
         enr_key: &K,
     ) -> Result<Option<Vec<u8>>, EnrError> {
         self.insert_raw_rlp(key, rlp::encode(&value), enr_key)
@@ -539,7 +539,7 @@ impl<K: EnrKey> Enr<K> {
     pub fn set_ip(&mut self, ip: IpAddr, key: &K) -> Result<Option<IpAddr>, EnrError> {
         match ip {
             IpAddr::V4(addr) => {
-                let prev_value = self.insert("ip", addr.octets().to_vec(), key)?;
+                let prev_value = self.insert("ip", &addr.octets(), key)?;
                 if let Some(bytes) = prev_value {
                     if bytes.len() == 4 {
                         let mut v = [0_u8; 4];
@@ -549,7 +549,7 @@ impl<K: EnrKey> Enr<K> {
                 }
             }
             IpAddr::V6(addr) => {
-                let prev_value = self.insert("ip6", addr.octets().to_vec(), key)?;
+                let prev_value = self.insert("ip6", &addr.octets(), key)?;
                 if let Some(bytes) = prev_value {
                     if bytes.len() == 16 {
                         let mut v = [0_u8; 16];
@@ -565,7 +565,7 @@ impl<K: EnrKey> Enr<K> {
 
     /// Sets the `udp` field of the ENR. Returns any pre-existing UDP port in the record.
     pub fn set_udp(&mut self, udp: u16, key: &K) -> Result<Option<u16>, EnrError> {
-        if let Some(udp_bytes) = self.insert("udp", udp.to_be_bytes().to_vec(), key)? {
+        if let Some(udp_bytes) = self.insert("udp", &udp.to_be_bytes(), key)? {
             if udp_bytes.len() <= 2 {
                 let mut v = [0_u8; 2];
                 v[2 - udp_bytes.len()..].copy_from_slice(&udp_bytes);
@@ -577,7 +577,7 @@ impl<K: EnrKey> Enr<K> {
 
     /// Sets the `udp6` field of the ENR. Returns any pre-existing UDP port in the record.
     pub fn set_udp6(&mut self, udp: u16, key: &K) -> Result<Option<u16>, EnrError> {
-        if let Some(udp_bytes) = self.insert("udp6", udp.to_be_bytes().to_vec(), key)? {
+        if let Some(udp_bytes) = self.insert("udp6", &udp.to_be_bytes(), key)? {
             if udp_bytes.len() <= 2 {
                 let mut v = [0_u8; 2];
                 v[2 - udp_bytes.len()..].copy_from_slice(&udp_bytes);
@@ -589,7 +589,7 @@ impl<K: EnrKey> Enr<K> {
 
     /// Sets the `tcp` field of the ENR. Returns any pre-existing tcp port in the record.
     pub fn set_tcp(&mut self, tcp: u16, key: &K) -> Result<Option<u16>, EnrError> {
-        if let Some(tcp_bytes) = self.insert("tcp", tcp.to_be_bytes().to_vec(), key)? {
+        if let Some(tcp_bytes) = self.insert("tcp", &tcp.to_be_bytes(), key)? {
             if tcp_bytes.len() <= 2 {
                 let mut v = [0_u8; 2];
                 v[2 - tcp_bytes.len()..].copy_from_slice(&tcp_bytes);
@@ -601,7 +601,7 @@ impl<K: EnrKey> Enr<K> {
 
     /// Sets the `tcp6` field of the ENR. Returns any pre-existing tcp6 port in the record.
     pub fn set_tcp6(&mut self, tcp: u16, key: &K) -> Result<Option<u16>, EnrError> {
-        if let Some(tcp_bytes) = self.insert("tcp6", tcp.to_be_bytes().to_vec(), key)? {
+        if let Some(tcp_bytes) = self.insert("tcp6", &tcp.to_be_bytes(), key)? {
             if tcp_bytes.len() <= 2 {
                 let mut v = [0_u8; 2];
                 v[2 - tcp_bytes.len()..].copy_from_slice(&tcp_bytes);
@@ -709,7 +709,7 @@ impl<K: EnrKey> Enr<K> {
 
     /// Sets a new public key for the record.
     pub fn set_public_key(&mut self, public_key: &K::PublicKey, key: &K) -> Result<(), EnrError> {
-        self.insert(&public_key.enr_key(), public_key.encode(), key)
+        self.insert(&public_key.enr_key(), &public_key.encode(), key)
             .map(|_| {})
     }
 
@@ -1217,7 +1217,7 @@ mod tests {
             builder.build(&key).unwrap()
         };
 
-        if let Err(e) = enr.insert("random", Vec::new(), &key) {
+        if let Err(e) = enr.insert("random", &Vec::new(), &key) {
             panic!(e);
         }
         assert!(enr.verify());


### PR DESCRIPTION
Long `map`/`and_then` chains caused the real verification result to be obscured behind layers of `Result`s.