### PR TITLE
Export-friendly traits

### DIFF
--- a/src/keys/ed25519.rs
+++ b/src/keys/ed25519.rs
@@ -1,6 +1,6 @@
 use super::{
     ed25519_dalek::{self as ed25519, Signer as _, Verifier as _},
-    EnrKey, EnrPublicKey, SigningError,
+    EnrKey, EnrKeyUnambiguous, EnrPublicKey, SigningError,
 };
 use crate::Key;
 use rlp::DecoderError;
@@ -34,7 +34,13 @@ impl EnrKey for ed25519::Keypair {
         // Decode the RLP
         let pubkey_bytes = rlp::Rlp::new(pubkey_bytes).data()?;
 
-        ed25519::PublicKey::from_bytes(pubkey_bytes)
+        Self::decode_public(pubkey_bytes)
+    }
+}
+
+impl EnrKeyUnambiguous for ed25519::Keypair {
+    fn decode_public(bytes: &[u8]) -> Result<Self::PublicKey, DecoderError> {
+        ed25519::PublicKey::from_bytes(bytes)
             .map_err(|_| DecoderError::Custom("Invalid ed25519 Signature"))
     }
 }

--- a/src/keys/k256_key.rs
+++ b/src/keys/k256_key.rs
@@ -1,6 +1,6 @@
 //! An implementation for `EnrKey` for `k256::ecdsa::SigningKey`
 
-use super::{EnrKey, EnrPublicKey, SigningError};
+use super::{EnrKey, EnrKeyUnambiguous, EnrPublicKey, SigningError};
 use crate::Key;
 use k256::{
     ecdsa::{
@@ -42,8 +42,14 @@ impl EnrKey for SigningKey {
         // Decode the RLP
         let pubkey_bytes = rlp::Rlp::new(pubkey_bytes).data()?;
 
+        Self::decode_public(pubkey_bytes)
+    }
+}
+
+impl EnrKeyUnambiguous for SigningKey {
+    fn decode_public(bytes: &[u8]) -> Result<Self::PublicKey, DecoderError> {
         // should be encoded in compressed form, i.e 33 byte raw secp256k1 public key
-        Ok(VerifyKey::new(pubkey_bytes)
+        Ok(VerifyKey::new(bytes)
             .map_err(|_| DecoderError::Custom("Invalid Secp256k1 Signature"))?)
     }
 }

--- a/src/keys/libsecp256k1.rs
+++ b/src/keys/libsecp256k1.rs
@@ -1,8 +1,7 @@
 //! An implementation for `EnrKey` for `libsecp256k1::SecretKey`
 
-use super::{secp256k1, EnrKey, EnrPublicKey, SigningError};
-use crate::digest;
-use crate::Key;
+use super::{secp256k1, EnrKey, EnrKeyUnambiguous, EnrPublicKey, SigningError};
+use crate::{digest, Key};
 use rlp::DecoderError;
 use std::collections::BTreeMap;
 
@@ -39,12 +38,15 @@ impl EnrKey for secp256k1::SecretKey {
         // Decode the RLP
         let pubkey_bytes = rlp::Rlp::new(pubkey_bytes).data()?;
 
+        Self::decode_public(pubkey_bytes)
+    }
+}
+
+impl EnrKeyUnambiguous for secp256k1::SecretKey {
+    fn decode_public(bytes: &[u8]) -> Result<Self::PublicKey, DecoderError> {
         // should be encoded in compressed form, i.e 33 byte raw secp256k1 public key
-        secp256k1::PublicKey::parse_slice(
-            pubkey_bytes,
-            Some(secp256k1::PublicKeyFormat::Compressed),
-        )
-        .map_err(|_| DecoderError::Custom("Invalid Secp256k1 Signature"))
+        secp256k1::PublicKey::parse_slice(bytes, Some(secp256k1::PublicKeyFormat::Compressed))
+            .map_err(|_| DecoderError::Custom("Invalid Secp256k1 Signature"))
     }
 }
 

--- a/src/keys/mod.rs
+++ b/src/keys/mod.rs
@@ -35,11 +35,11 @@ use rlp::DecoderError;
 use std::{
     collections::BTreeMap,
     error::Error,
-    fmt::{self, Display},
+    fmt::{self, Debug, Display},
 };
 
 /// The trait required for a key to sign and modify an ENR record.
-pub trait EnrKey {
+pub trait EnrKey: Send + Sync + Unpin + 'static {
     type PublicKey: EnrPublicKey + Clone;
 
     /// Performs ENR-specific signing for the `v4` identity scheme.
@@ -58,7 +58,7 @@ pub trait EnrKey {
 }
 
 /// The trait required for a `PublicKey` to verify an ENR record.
-pub trait EnrPublicKey {
+pub trait EnrPublicKey: Clone + Debug + Send + Sync + Unpin + 'static {
     /// Verify an ENR signature for the `v4` identity scheme.
     fn verify_v4(&self, msg: &[u8], sig: &[u8]) -> bool;
 

--- a/src/keys/mod.rs
+++ b/src/keys/mod.rs
@@ -57,6 +57,12 @@ pub trait EnrKey: Send + Sync + Unpin + 'static {
     fn enr_to_public(content: &BTreeMap<Key, Vec<u8>>) -> Result<Self::PublicKey, DecoderError>;
 }
 
+/// Trait for keys that are uniquely represented
+pub trait EnrKeyUnambiguous: EnrKey {
+    /// Decode raw bytes as corresponding public key.
+    fn decode_public(bytes: &[u8]) -> Result<Self::PublicKey, DecoderError>;
+}
+
 /// The trait required for a `PublicKey` to verify an ENR record.
 pub trait EnrPublicKey: Clone + Debug + Send + Sync + Unpin + 'static {
     /// Verify an ENR signature for the `v4` identity scheme.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -199,7 +199,7 @@ pub use keys::secp256k1;
 #[cfg(all(feature = "ed25519", feature = "k256"))]
 pub use keys::{ed25519_dalek, CombinedKey, CombinedPublicKey};
 
-pub use keys::{EnrKey, EnrPublicKey};
+pub use keys::{EnrKey, EnrKeyUnambiguous, EnrPublicKey};
 pub use node_id::NodeId;
 use std::marker::PhantomData;
 


### PR DESCRIPTION
This is not strictly necessary for `enr` itself, but is required for crates that are based on `enr` (e.g. `dnsdisc`) and want to be generic over the keys, just like `enr::Enr` itself.