### PR TITLE
secp256k1: reuse context

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ sha3 = "0.9"
 k256 = { version = "0.5", features = ["ecdsa", "zeroize"], optional = true }
 serde = { version = "1.0.110", optional = true }
 ed25519-dalek = { version = "1.0.0-pre.4", optional = true }
-c-secp256k1 = { package = "secp256k1", version = "0.19", optional = true }
+c-secp256k1 = { package = "secp256k1", version = "0.19", optional = true, features = ["global-context"] }
 
 [dev-dependencies]
 c-secp256k1 = { package = "secp256k1", features = ["rand-std"], version = "0.19" }

--- a/src/keys/rust_secp256k1.rs
+++ b/src/keys/rust_secp256k1.rs
@@ -1,6 +1,6 @@
 use super::{EnrKey, EnrPublicKey, SigningError};
-use crate::digest;
-use crate::Key;
+use crate::{digest, Key};
+use c_secp256k1::SECP256K1;
 use rlp::DecoderError;
 use std::collections::BTreeMap;
 
@@ -16,14 +16,11 @@ impl EnrKey for c_secp256k1::SecretKey {
         let m = c_secp256k1::Message::from_slice(&hash)
             .map_err(|_| SigningError::new("failed to parse secp256k1 digest"))?;
         // serialize to an uncompressed 64 byte vector
-        Ok(c_secp256k1::Secp256k1::new()
-            .sign(&m, self)
-            .serialize_compact()
-            .to_vec())
+        Ok(SECP256K1.sign(&m, self).serialize_compact().to_vec())
     }
 
     fn public(&self) -> Self::PublicKey {
-        Self::PublicKey::from_secret_key(&c_secp256k1::Secp256k1::new(), self)
+        Self::PublicKey::from_secret_key(SECP256K1, self)
     }
 
     fn enr_to_public(content: &BTreeMap<Key, Vec<u8>>) -> Result<Self::PublicKey, DecoderError> {
@@ -43,9 +40,7 @@ impl EnrPublicKey for c_secp256k1::PublicKey {
         let msg = digest(msg);
         if let Ok(sig) = c_secp256k1::Signature::from_compact(sig) {
             if let Ok(msg) = c_secp256k1::Message::from_slice(&msg) {
-                return c_secp256k1::Secp256k1::new()
-                    .verify(&msg, &sig, self)
-                    .is_ok();
+                return SECP256K1.verify(&msg, &sig, self).is_ok();
             }
         }
         false


### PR DESCRIPTION
Creating context is a very heavy operation - we can and should use global one instead.