### PR TITLE
Avoid allocations in RLP `decode` impl for `Enr`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -878,7 +878,7 @@ impl<K: EnrKey> rlp::Decodable for Enr<K> {
         let seq = u64::from_be_bytes(seq);
 
         let mut content = BTreeMap::new();
-        let mut prev: Option<Key> = None;
+        let mut prev: Option<&[u8]> = None;
         while let Some(key) = rlp_iter.next() {
             let key = key.data()?;
             let item = rlp_iter
@@ -889,10 +889,10 @@ impl<K: EnrKey> rlp::Decodable for Enr<K> {
             let _ = item.data()?;
             let value = item.as_raw();
 
-            if prev.is_some() && prev.as_deref() >= Some(key) {
+            if prev.is_some() && prev >= Some(key) {
                 return Err(DecoderError::Custom("Unsorted keys"));
             }
-            prev = Some(key.to_vec());
+            prev = Some(key);
             content.insert(key.to_vec(), Bytes::copy_from_slice(value));
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -851,15 +851,21 @@ impl<K: EnrKey> rlp::Decodable for Enr<K> {
             return Err(DecoderError::RlpExpectedToBeList);
         }
 
-        let mut decoded_list: Vec<Rlp> = rlp.iter().collect();
+        let mut rlp_iter = rlp.iter();
 
-        if decoded_list.is_empty() || decoded_list.len() % 2 != 0 {
+        if rlp_iter.len() == 0 || rlp_iter.len() % 2 != 0 {
             debug!("Failed to decode ENR. List size is not a multiple of 2.");
             return Err(DecoderError::Custom("List not a multiple of two"));
         }
 
-        let signature = decoded_list.remove(0).data()?;
-        let seq_bytes = decoded_list.remove(0).data()?;
+        let signature = rlp_iter
+            .next()
+            .ok_or(DecoderError::Custom("List is empty"))?
+            .data()?;
+        let seq_bytes = rlp_iter
+            .next()
+            .ok_or(DecoderError::Custom("List has only one item"))?
+            .data()?;
 
         if seq_bytes.len() > 8 {
             debug!("Failed to decode ENR. Sequence number is not a u64.");
@@ -873,19 +879,21 @@ impl<K: EnrKey> rlp::Decodable for Enr<K> {
 
         let mut content = BTreeMap::new();
         let mut prev: Option<Key> = None;
-        for _ in 0..decoded_list.len() / 2 {
-            let key = decoded_list.remove(0).data()?.to_vec();
-            let item = decoded_list.remove(0);
+        while let Some(key) = rlp_iter.next() {
+            let key = key.data()?;
+            let item = rlp_iter
+                .next()
+                .ok_or(DecoderError::Custom("List not a multiple of 2"))?;
 
             // Sanitize the data
             let _ = item.data()?;
             let value = item.as_raw();
 
-            if prev.is_some() && prev.as_ref() >= Some(&key) {
+            if prev.is_some() && prev.as_deref() >= Some(key) {
                 return Err(DecoderError::Custom("Unsorted keys"));
             }
-            prev = Some(key.clone());
-            content.insert(key, Bytes::copy_from_slice(value));
+            prev = Some(key.to_vec());
+            content.insert(key.to_vec(), Bytes::copy_from_slice(value));
         }
 
         // verify we know the signature type


### PR DESCRIPTION
Whilst poking around Lighthouse memory usage, I noticed this `Enr::decode` function is responsible for a significant portion of our temporary allocations. I'm not convinced it's an *actual problem*, but it seems like a fun target for optimisation.

I've switched to using the [`RlpIterator`](https://docs.rs/rlp/0.5.1/rlp/struct.RlpIterator.html) directly, rather than allocating it to a `Vec` first. I've also avoided cloning the `Key` into a `Vec` for each item in the list.

There's a bit of redundancy regarding the "Failed to decode ENR..." debug log, all the checks there are also checked later in the function. I left it in, LMK if you'd like it removed.